### PR TITLE
Update .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,3 +13,6 @@ omit =
     *__init__*
     # Omit any file with admin (admin.py)
     *admin*   
+    *wsgi.py
+    */apps.py
+    */*test*.py


### PR DESCRIPTION
Checking out how far our coverage would drop if we omit apps.py, tests. With forms.py omitted aswell we were at 30%

don't merge, want to see the coveralls