### PR TITLE
Implement Tox to Grepthink

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ sendgrid
 django-gravatar2
 xlwt
 Django==1.11.18 
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,99 @@
+# Quicktro
+# --------
+#
+# To use, run::
+#
+#     tox
+#
+# To list all entry points and their descriptions, run::
+#
+#     tox -alv
+#
+[tox]
+envlist=flake8,docformatter,pydocstyle,isort
+skipsdist=True
+
+[testenv]
+# The default environment. All other environments extend this one.
+basepython = python3.6
+passenv = USER
+
+[pylint]
+deps =
+    pylint==2.3.1
+
+[flake8]
+# E501: line too long (other tools check line length)
+# E704: multiple statements on one line (we like that, for lambdas!)
+# E731: do not assign a lambda expression, use a def
+# W503,W504: https://github.com/PyCQA/pycodestyle/issues/498#issue-148719255
+# Both flake8 and pycodestyle configuration overlap, be sure to update both!
+ignore = E501,W503,W504,E704,E731,E701
+max-line-length = 100
+exclude = .tox
+deps =
+    entrypoints==0.3
+    flake8==3.7.5
+    mccabe==0.6.1
+    pycodestyle==2.5.0
+    pyflakes==2.1.0
+
+[pycodestyle]
+# Both flake8 and pycodestyle configuration overlap, be sure to update both!
+ignore = E501,W503,W504,E704,E731,E701
+max-line-length = 100
+statistics = True
+explain = True
+deps =
+    autopep8==1.4.3
+    pycodestyle==2.5.0
+
+[docformatter]
+deps =
+    docformatter==1.0
+    untokenize==0.1.1
+
+[pydocstyle]
+# D101: Missing docstring in public class
+# D212: Multi-line docstring summary should start at the first line
+# D203,D204: 1 blank line required before/after class docstring
+ignore = D101,D212,D203,D204
+deps = pydocstyle==3.0.0
+    six==1.12.0
+    snowballstemmer==1.2.1
+
+[testenv:flake8]
+description = Quick and basic Lint using 'flake8' Tool
+deps = {[flake8]deps}
+commands = {envbindir}/flake8
+
+[testenv:pydocstyle]
+description = Checks docstrings for compliance with a subset of PEP 257 conventions
+deps =
+    {[pydocstyle]deps}
+commands =
+    {envbindir}/pydocstyle --source --explain \
+        --add-ignore D101,D212,D213,D203,D204 \
+        {toxinidir}
+
+[testenv:docformatter]
+description = Automatically formats docstrings to follow a subset of the PEP 257 conventions
+deps =
+    {[docformatter]deps}
+commands =
+    {envbindir}/docformatter \
+        --recursive \
+        --pre-summary-newline \
+        --wrap-summaries=100 \
+        --wrap-descriptions=100 \
+        {posargs:in_place} \
+        {toxinidir}
+
+[testenv:isort]
+description = Automatically sort python imports
+deps =
+    isort==4.3.17
+commands =
+    {envbindir}/isort --quiet --apply --recursive \
+    {toxinidir}
+


### PR DESCRIPTION
Implement tox to handle linting/codeformatting for our code base.

To run, in the base directory call
`tox` from the command line

To run an individual environment, such as `flake8` we can use
`tox -e flake8`

This has the potential to act as a unified test environment for our platform, we can use this to run any potential tests we have ensuring that each person running it is using the same environment