### PR TITLE
Duplicate username signup patch

### DIFF
--- a/teamwork/apps/profiles/forms.py
+++ b/teamwork/apps/profiles/forms.py
@@ -29,7 +29,7 @@ def SignupDomainValidator(value):
 
 
 def ForbiddenUsernamesValidator(value):
-    forbidden_usernames = ['admin', 'settings', 'news', 'about', 'help',
+    forbidden_usernames = ['admin', 'accounting', 'settings', 'news', 'about', 'help',
                            'signin', 'signup', 'signout', 'terms', 'privacy',
                            'cookie', 'new', 'login', 'logout', 'administrator',
                            'join', 'account', 'username', 'root', 'blog',
@@ -45,7 +45,7 @@ def ForbiddenUsernamesValidator(value):
                            'media', 'setting', 'css', 'js', 'follow',
                            'activity', 'questions', 'articles', 'network',
                            'grepthink', 'gt', 'groupthink', 'alphanumeric'
-                           'teamwork']
+                           'teamwork', 'support']
 
     if value.lower() in forbidden_usernames:
         raise ValidationError('This is a reserved word.')

--- a/teamwork/apps/profiles/tests.py
+++ b/teamwork/apps/profiles/tests.py
@@ -1,3 +1,32 @@
 from django.test import TestCase
+from django.contrib.auth.models import User
+
+from teamwork.apps.profiles.views.BaseView import find_available_username
 
 # Create your tests here.
+class DuplicateSignUpTest(TestCase):
+    """
+    Creates a user and asserts return values are correct from authenticate method
+    """
+    def setUp(self):
+        """
+        Init any variables that are needed for testing
+        """
+        self.user1 = User.objects.create_user('test', 'test@testing.com', 'pw')
+
+    def tearDown(self):
+        """
+        Delete any variables that were created for testing
+        """
+        del self.user1
+
+    def test_next_available_username(self):
+        """
+        Attempt to authenticate user w/ correct email address and pw and assert user object is returned
+        """
+        next_username = find_available_username("test")
+        self.assertTrue(next_username == "test1")
+
+        self.user2 = User.objects.create_user('test1', 'test@another.com', 'pw')
+        next_username = find_available_username("test")
+        self.assertTrue(next_username == "test2")

--- a/teamwork/apps/profiles/tests.py
+++ b/teamwork/apps/profiles/tests.py
@@ -24,9 +24,17 @@ class DuplicateSignUpTest(TestCase):
         """
         Attempt to authenticate user w/ correct email address and pw and assert user object is returned
         """
+        # Find the next available username
         next_username = find_available_username("test")
+
+        # assert it is test1
         self.assertTrue(next_username == "test1")
 
+        # create that user w/ username test1
         self.user2 = User.objects.create_user('test1', 'test@another.com', 'pw')
+
+        # next iteration should find that the next avail username is test2
         next_username = find_available_username("test")
+        
+        # assert it is test2
         self.assertTrue(next_username == "test2")

--- a/teamwork/apps/profiles/views/BaseView.py
+++ b/teamwork/apps/profiles/views/BaseView.py
@@ -74,7 +74,7 @@ def profSignup(request):
         else:
             email = form.cleaned_data.get('email')
             split = email.split("@")
-            username = split[0]            
+            username = find_available_username(split[0])
             password = form.cleaned_data.get('password')
             
             user1 = User.objects.create_user(

--- a/teamwork/apps/profiles/views/BaseView.py
+++ b/teamwork/apps/profiles/views/BaseView.py
@@ -9,39 +9,6 @@ from teamwork.apps.profiles.forms import SignUpForm
 # View Imports
 from teamwork.apps.profiles.views.EditProfileView import edit_profile
 
-def find_available_username(username):
-    """
-    checks if the passed username is available to be used.
-    If not, then return the 'username + #' available
-    """
-
-    # Find users with that username in descending order
-    existing_users = User.objects.filter(username__istartswith=username).order_by('-username')
-
-    # if we found users, parse out value from the highest username
-    if existing_users:
-        # since we are in desc order, this is always the first user
-        user = existing_users[0]
-
-        # parse out the int value applied to the end of username
-        value = parse_username_num(user, username)
-        if value is None:
-            value = 0
-
-        # add 1 to the found value and append it to the username        
-        return "{}{}".format(username, value + 1)
-
-    return username
-
-def parse_username_num(user, username_to_parse):
-    """
-    Parses out the number at the end of a user's username given the base username w/o the number
-    """
-    try:
-        return int(user.username[len(username_to_parse):])
-    except ValueError:
-        return None
-
 def signup(request):
     """
     public method that generates a form a user uses to sign up for an account (push test)
@@ -133,6 +100,52 @@ def profSignup(request):
         return render(request, 'profiles/professorSignup.html',
                       {'form': SignUpForm(), 'page_name' : page_name,
                       'page_description': page_description, 'title': title})
+
+def find_available_username(username):
+    """
+    Finds the next available username.
+
+    Args:
+        username (str): The desired username
+
+    Returns:
+        str: The desired username w/ the next available number appended to the end.
+    """
+
+    # Find users with that username in descending order
+    existing_users = User.objects.filter(username__istartswith=username).order_by('-username')
+
+    # if we found users, parse out value from the highest username
+    if existing_users:
+        # since we are in desc order, this is always the first user
+        user = existing_users[0]
+
+        # parse out the int value applied to the end of username
+        value = parse_username_num(user, username)
+        if value is None:
+            value = 0
+
+        # add 1 to the found value and append it to the username        
+        return "{}{}".format(username, value + 1)
+
+    return username
+
+def parse_username_num(user, username_to_parse):
+    """
+    Parses out the number at the end of a user's username given the base username w/o the number
+
+    Args:
+        user (User): The User object which we are parsing the number from.
+        username_to_parse (str): The core of the username, before any numbers appended to the end.
+
+    Returns:
+        int: On Success, the value parsed.
+        None: On Fail or when a number doesn't exist. I.e this is the 2nd user to want this username.
+    """
+    try:
+        return int(user.username[len(username_to_parse):])
+    except ValueError:
+        return None
 
 def password_reset(request):
     return


### PR DESCRIPTION
When signing up, if a username exists, append the next available # to the end of the username.

i.e:

1. signing up with kp@gmail.com will create user w/ username 'kp'
2. signing up with kp@yahoo.com will create user w/ username 'kp1'
3. signing up with kp@aol.com will create user w/ username 'kp2'
.
.
.
