### PR TITLE
Reserved email fixes

### DIFF
--- a/teamwork/apps/profiles/forms.py
+++ b/teamwork/apps/profiles/forms.py
@@ -29,6 +29,12 @@ def SignupDomainValidator(value):
 
 
 def ForbiddenEmailValidator(value):
+    """
+    Splits an email address by @, and determines if the first portion is a forbidden username
+
+    Args:
+        value: (str) The email address to be parsed
+    """
     forbidden_usernames = ['admin', 'accounting', 'settings', 'news', 'about', 'help',
                            'signin', 'signup', 'signout', 'terms', 'privacy',
                            'cookie', 'new', 'login', 'logout', 'administrator',

--- a/teamwork/apps/profiles/forms.py
+++ b/teamwork/apps/profiles/forms.py
@@ -28,7 +28,7 @@ def SignupDomainValidator(value):
             raise ValidationError('Invalid domain. Allowed domains on this network: {0}'.format(','.join(ALLOWED_SIGNUP_DOMAINS)))  # noqa: E501
 
 
-def ForbiddenUsernamesValidator(value):
+def ForbiddenEmailValidator(value):
     forbidden_usernames = ['admin', 'accounting', 'settings', 'news', 'about', 'help',
                            'signin', 'signup', 'signout', 'terms', 'privacy',
                            'cookie', 'new', 'login', 'logout', 'administrator',
@@ -47,8 +47,12 @@ def ForbiddenUsernamesValidator(value):
                            'grepthink', 'gt', 'groupthink', 'alphanumeric'
                            'teamwork', 'support']
 
-    if value.lower() in forbidden_usernames:
-        raise ValidationError('This is a reserved word.')
+    split = value.split("@")
+    username = split[0]
+
+    if username:
+        if username.lower() in forbidden_usernames:
+            raise ValidationError('Email address contains a reserved word.')    
 
 
 def InvalidUsernameValidator(value):
@@ -93,6 +97,7 @@ class SignUpForm(forms.ModelForm):
         super(SignUpForm, self).__init__(*args, **kwargs)
         self.fields['email'].validators.append(UniqueEmailValidator)
         self.fields['email'].validators.append(SignupDomainValidator)
+        self.fields['email'].validators.append(ForbiddenEmailValidator)
 
     def clean(self):
         super(SignUpForm, self).clean()

--- a/teamwork/apps/profiles/tests.py
+++ b/teamwork/apps/profiles/tests.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from django.contrib.auth.models import User
 
 from teamwork.apps.profiles.views.BaseView import find_available_username
+from teamwork.apps.profiles.forms import SignUpForm
 
 # Create your tests here.
 class DuplicateSignUpTest(TestCase):
@@ -38,3 +39,25 @@ class DuplicateSignUpTest(TestCase):
         
         # assert it is test2
         self.assertTrue(next_username == "test2")
+
+class SignupValidationTest(TestCase):
+    """
+    Test Signup Validation
+    """
+    def test_reserved_word_raises_error(self):
+        """
+        Assure that using a reserved word raises ValidationError
+        """
+        entered_email = "admin@testing.com"
+        pw = "passwordtest"
+        sign_up_form = SignUpForm(data={'email': entered_email, 'password':pw, 'confirm_password': pw})        
+        self.assertFalse(sign_up_form.is_valid())
+
+    def test_successful_entry(self):
+        """
+        Assure that using a valid email address doesn't raise ValidationError
+        """
+        entered_email = "kp123@testing.com"
+        pw = "passwordtest"        
+        sign_up_form = SignUpForm(data={'email': entered_email, 'password': pw, 'confirm_password': pw})
+        self.assertTrue(sign_up_form.is_valid())


### PR DESCRIPTION
When signing up, users cannot use an email address that would create a username of a reserved word.