### PR TITLE
landing page cleanup and dev email handling

### DIFF
--- a/teamwork/apps/core/helpers.py
+++ b/teamwork/apps/core/helpers.py
@@ -40,11 +40,11 @@ def send_email(recipients, gt_email, subject, content):
 
     student_email_list = []
 
-    if type(recipients) is User:
+    if isinstance(recipients, User):
         # only 1 member
         student_email_list.append(Email(recipients.email))
-    elif type(recipients) is list:
-        if type(recipients[0]) is str:
+    elif isinstance(recipients, list):
+        if isinstance(recipients[0], str):
             for student in recipients:
                 student_email_list.append(Email(student))
         else:
@@ -53,8 +53,7 @@ def send_email(recipients, gt_email, subject, content):
                 student_email_list.append(Email(student.email))
     else:
         return HttpResponseBadRequest("Bad Request")
-
-    print("settings.EMAIL_SENDGRID_KEY:", settings.EMAIL_SENDGRID_KEY)
+    
     # Handle email sending
     sg = SendGridAPIClient(settings.EMAIL_SENDGRID_KEY)
 
@@ -63,21 +62,25 @@ def send_email(recipients, gt_email, subject, content):
     mail.subject = subject
     mail.add_content(Content("text/plain", content))
 
-    # add recipients to the outgoing Mail object
-    # creating Personalization instances makes it so everyone can't see everyone elses emails in the 'to:' of the email
-    for email in student_email_list:
+    if settings.DEBUG:
+        # if debug, send email to grepthink email
         p = Personalization()
-        p.add_to(email)
+        # If you wish to reeive emails to personal email you can refector the below email. Please don't update repo though
+        p.add_to(Email("testing@grepthink.com"))
         mail.add_personalization(p)
+    else:
+        # add recipients to the outgoing Mail object
+        # creating Personalization instances makes it so everyone can't see everyone elses emails in the 'to:' of the email
+        for email in student_email_list:
+            p = Personalization()
+            p.add_to(email)
+            mail.add_personalization(p)
 
     # The following line was giving SSL Certificate errors.
     # Solution at: https://stackoverflow.com/questions/27835619/urllib-and-ssl-certificate-verify-failed-error/42334357#42334357
 
     # Send the Email
     response = sg.client.mail.send.post(request_body=mail.get())
-    # print(response.status_code)
-    # print(response.body)
-    # print(response.headers)
 
     return HttpResponse("Email Sent!")
 

--- a/teamwork/apps/core/views/LandingView.py
+++ b/teamwork/apps/core/views/LandingView.py
@@ -6,54 +6,71 @@ from teamwork.apps.courses.models import Course, get_user_active_courses, get_us
 
 def index(request):
     """
-    The main index of Teamwork, referred to as "Home" in the sidebar.
+    The main index of grepthink, referred to as "Home" in the sidebar.
     Accessible to public and logged in users.
-    """
-    # TODO: get feed of project updates (or public projects) to display on login
 
-    # Populate with defaults for not logged in user
+    TODO: get feed of project updates (or public projects) to display on login
+    """
+    # Render landing page for not logged in user
+    logged_in = request.user.is_authenticated()
+    if not logged_in:
+        return render_landing(request)
+
+    # If the user is a professor, render their dashboard
+    if request.user.profile.isProf:
+        return render_dashboard(request)
+
+    # Otherwise render timeline
+    return render_timeline(request)
+
+def render_landing(request):
+    """
+    Renders Landing Page
+    """
     page_name = "Grepthink"
     page_description = "Build Better Teams"
     title = "Welcome"
-    date_updates = None
-    logged_in = request.user.is_authenticated();
 
-    if not logged_in:
-        return render(request, 'core/landing.html', {
+    return render(request, 'core/landing.html', {
                 'page_name' : page_name,
                 'page_description' : page_description, 'title' : title
                 })
 
-    # If the user is a professor, return the dashboard html
-    if logged_in and request.user.profile.isProf:
-        page_name = "Dashboard"
-        page_description = "Instructor Control Panel"
-        title = "Dashboard"
-        active_courses = get_user_active_courses(request.user)
-        disabled_courses = get_user_disabled_courses(request.user)
-        return render(request, 'core/dashboard.html', {
-                'page_name' : page_name,
-                'page_description' : page_description, 'title' : title,
-                'active_courses' : active_courses, 'disabled_courses': disabled_courses
-                })
+def render_dashboard(request):
+    """
+    Renders Professor Dashboard
+    """
+    page_name = "Dashboard"
+    page_description = "Instructor Control Panel"
+    title = "Dashboard"
+    active_courses = get_user_active_courses(request.user)
+    disabled_courses = get_user_disabled_courses(request.user)
 
-    if logged_in:
-        page_name = "Timeline"
-        page_description = "Recent Updates from Courses and Projects"
-        title = "Timeline"
+    return render(request, 'core/dashboard.html', {
+        'page_name' : page_name,
+        'page_description' : page_description, 'title' : title,
+        'active_courses' : active_courses, 'disabled_courses': disabled_courses
+        })
 
-        all_courses = get_user_active_courses(request.user)
+def render_timeline(request):
+    """
+    Render the Student Timeline
+    """
+    page_name = "Timeline"
+    page_description = "Recent Updates from Courses and Projects"
+    title = "Timeline"
 
-        date_updates = []
-        for course in all_courses:
-            course_updates = course.get_updates_by_date()
-            date_updates.extend(course.get_updates_by_date())
+    all_courses = get_user_active_courses(request.user)
+
+    date_updates = []
+    for course in all_courses:        
+        date_updates.extend(course.get_updates_by_date())
 
     return render(request, 'core/index.html', {
-            'page_name' : page_name,
-            'page_description' : page_description, 'title' : title,
-            'date_updates' : date_updates, 'logged_in' : logged_in
-            })
+        'page_name' : page_name,
+        'page_description' : page_description, 'title' : title,
+        'date_updates' : date_updates, 'logged_in' : True
+        })
 
 def disable(request, slug):
     """


### PR DESCRIPTION
Factored out the index view into 3 separate helpers:
* render_landing, render_dashboard, render_timeline

When running w/ env variable DEBUG set to True:
* Emails will only be sent to 'testing@grepthink.com'.